### PR TITLE
Disable KillTrack in instances (FPS improve)

### DIFF
--- a/KillTrack.lua
+++ b/KillTrack.lua
@@ -143,6 +143,12 @@ function KT.Events.ADDON_LOADED(self, ...)
 	if type(self.Global.BROKER.MINIMAP) ~= "table" then
 		self.Global.BROKER.MINIMAP = {}
 	end
+	if type(self.Global.DISABLE_DUNGEONS) ~= "boolean" then
+		self.Global.DISABLE_DUNGEONS = false
+	end
+	if type(self.Global.DISABLE_RAIDS) ~= "boolean" then
+		self.Global.DISABLE_RAIDS = false
+	end
 	if type(_G["KILLTRACK_CHAR"]) ~= "table" then
 		_G["KILLTRACK_CHAR"] = {}
 	end
@@ -237,6 +243,22 @@ end
 
 function KT.Events.CHAT_MSG_COMBAT_XP_GAIN(self, message)
 	ET:CheckMessage(message)
+end
+
+function KT.Events.ENCOUNTER_START(self, encounterID, name, difficulty, size)
+	if (self.Global.DISABLE_DUNGEONS and size == 5) or (self.Global.DISABLE_RAIDS and size > 5) then
+		self.Frame:UnregisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+		self.Frame:UnregisterEvent("UPDATE_MOUSEOVER_UNIT")
+		self.Frame:UnregisterEvent("CHAT_MSG_COMBAT_XP_GAIN")
+	end
+end
+
+function KT.Events.ENCOUNTER_END(self, encounterID, name, difficulty, size)
+	if (self.Global.DISABLE_DUNGEONS and size == 5) or (self.Global.DISABLE_RAIDS and size > 5) then
+		self.Frame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+		self.Frame:RegisterEvent("UPDATE_MOUSEOVER_UNIT")
+		self.Frame:RegisterEvent("CHAT_MSG_COMBAT_XP_GAIN")
+	end
 end
 
 function KT:ToggleExp()

--- a/Options.lua
+++ b/Options.lua
@@ -162,12 +162,28 @@ function Opt:Show()
         end)
     minimap:SetPoint("TOPLEFT", purge, "BOTTOMLEFT", 0, -8)
 
+    local disableDungeons = checkbox("Disable in dungeons (save CPU)",
+        "With this is checked, mob kills in dungeons won't be counted.",
+        function(check, checked)
+            KT.Global.DISABLE_DUNGEONS = checked
+        end)
+    disableDungeons:SetPoint("TOPLEFT", minimap, "BOTTOMLEFT", 0, -8)
+
+    local disableRaids = checkbox("Disable in raids (save CPU)",
+        "With this is checked, mob kills in raids won't be counted.",
+        function(check, checked)
+            KT.Global.DISABLE_RAIDS = checked
+        end)
+    disableRaids:SetPoint("TOPLEFT", disableDungeons, "BOTTOMLEFT", 0, -8)
+
     local function init()
         printKills:SetChecked(KT.Global.PRINT)
         printNew:SetChecked(KT.Global.PRINTNEW)
         countGroup:SetChecked(KT.Global.COUNT_GROUP)
         threshold:SetText(KT.Global.ACHIEV_THRESHOLD)
         minimap:SetChecked(not KT.Global.BROKER.MINIMAP.hide)
+        disableDungeons:SetChecked(KT.Global.DISABLE_DUNGEONS)
+        disableRaids:SetChecked(KT.Global.DISABLE_RAIDS)
     end
 
     init()

--- a/Options.lua
+++ b/Options.lua
@@ -37,7 +37,7 @@ local function checkbox(label, description, onclick)
     local check = CreateFrame("CheckButton", "KillTrackOptCheck" .. checkCounter, panel, "InterfaceOptionsCheckButtonTemplate")
     check:SetScript("OnClick", function(self)
         local checked = self:GetChecked()
-        PlaySound(checked and "igMainMenuOptionCheckBoxOn" or "igMainMenuOptionCheckBoxOff")
+        PlaySound(checked and SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON or SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_OFF)
         onclick(self, checked and true or false)
     end)
     check.label = _G[check:GetName() .. "Text"]

--- a/Options.lua
+++ b/Options.lua
@@ -163,14 +163,14 @@ function Opt:Show()
     minimap:SetPoint("TOPLEFT", purge, "BOTTOMLEFT", 0, -8)
 
     local disableDungeons = checkbox("Disable in dungeons (save CPU)",
-        "With this is checked, mob kills in dungeons won't be counted.",
+        "When this is checked, mob kills in dungeons won't be counted.",
         function(check, checked)
             KT.Global.DISABLE_DUNGEONS = checked
         end)
     disableDungeons:SetPoint("TOPLEFT", minimap, "BOTTOMLEFT", 0, -8)
 
     local disableRaids = checkbox("Disable in raids (save CPU)",
-        "With this is checked, mob kills in raids won't be counted.",
+        "When this is checked, mob kills in raids won't be counted.",
         function(check, checked)
             KT.Global.DISABLE_RAIDS = checked
         end)


### PR DESCRIPTION
Two new configuration options were added: "Disable in dungeons" and "Disable in raids".